### PR TITLE
Add npm to fix npm-missing-error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,5 @@ COPY nodejs.sources.list /etc/apt/sources.list.d
 COPY nodesource.gpg.key /root
 RUN apt-key add /root/nodesource.gpg.key
 
-RUN apt-get update && apt-get -y install nodejs && apt-get -y clean
+RUN apt-get update && apt-get -y install nodejs npm && apt-get -y clean
 RUN npm install yarn -g


### PR DESCRIPTION
Hi, 

i tried to build the image localy and it failed on the last step. Npm doesn't seem to be part of the nodejs package anymore.

This fixed it for me.